### PR TITLE
Fix HEMTT path

### DIFF
--- a/build-hemtt.bat
+++ b/build-hemtt.bat
@@ -12,7 +12,7 @@ if exist x\grad_trenches\addons (
 )
 mklink /j x\grad_trenches\addons addons
 
-hemtt build --force --release
+tools\hemtt build --force --release
 set BUILD_STATUS=%errorlevel%
 
 rmdir a3


### PR DESCRIPTION
The build-hemtt.bat did only work if you copied the hemtt.exe into the root folder. Or you have hemtt.exe in the PATH variable. 

Now the "build-hemtt.bat" uses always the hemtt.exe from the tools folder.