### PR TITLE
Fix sound position

### DIFF
--- a/addons/functions/functions/fnc_playSound.sqf
+++ b/addons/functions/functions/fnc_playSound.sqf
@@ -19,4 +19,4 @@
 params ["_trench"];
 
 private _sound = str (selectRandom [1,2,3,4,5,6,7]);
-playSound3D ["x\grad_trenches\addons\sounds\dig" + _sound + ".ogg", _trench, false, getpos _trench, 1, 1, 100];
+playSound3D ["x\grad_trenches\addons\sounds\dig" + _sound + ".ogg", _trench, false, getPosASL _trench, 1, 1, 100];


### PR DESCRIPTION
On some maps, due to `getPos`, the sound is not audible. Better use `getPosASL`.