### PR TITLE
Player detection for trench decay + tweaks

### DIFF
--- a/addons/functions/functions/fnc_decayPFH.sqf
+++ b/addons/functions/functions/fnc_decayPFH.sqf
@@ -51,6 +51,12 @@ GVAR(decayPFH) = [{
             _newArray pushBack [_trench, _timeoutToDecay, _decayTimeMax];
         } else {
             if (_timeoutToDecay <= 10) then {
+                // If there are players in the area and CBA setting enabled, reset trench decay
+                if (GVAR(playersInAreaRadius) isNotEqualTo 0 && {(((ASLToAGL getPosASL _trench) nearEntities ["CAManBase", GVAR(playersInAreaRadius)]) select {isPlayer _x}) isNotEqualTo []}) then {
+                    _newArray pushBack [_trench, GVAR(timeoutToDecay), GVAR(decayTime)];
+                    continue;
+                };
+
                 private _progress = _trench getVariable ["ace_trenches_progress", 0];
                 _progress = _progress - (10 / (_decayTimeMax max 10)); // In case _decayTimeMax is set to 0
 
@@ -58,6 +64,10 @@ GVAR(decayPFH) = [{
                     deleteVehicle _trench;
                 } else {
                     [_trench, _progress, 1] call FUNC(setTrenchProgress);
+
+                    if (GVAR(allowEffects)) then {
+                        [QGVAR(digFX), [_trench]] call CBA_fnc_globalEvent;
+                    };
 
                     _newArray pushBack [_trench, 0, _decayTimeMax];
                 };

--- a/addons/functions/functions/fnc_placeCamouflage.sqf
+++ b/addons/functions/functions/fnc_placeCamouflage.sqf
@@ -44,6 +44,6 @@ if (isNull _unit) exitWith {
     [[objnull, _trench]] call _fnc_onFinish;
 };
 
-[CAMOUFLAGE_DURATION, [_unit, _trench], _fnc_onFinish, _fnc_onFailure, localize LSTRING(placeCamouflageProgress)] call ace_common_fnc_progressBar;
+[CAMOUFLAGE_DURATION, [_unit, _trench], _fnc_onFinish, _fnc_onFailure, LLSTRING(placeCamouflageProgress)] call ace_common_fnc_progressBar;
 
 [_unit, "AinvPknlMstpSnonWnonDnon_medic4"] call ace_common_fnc_doAnimation;

--- a/addons/functions/functions/fnc_removeCamouflage.sqf
+++ b/addons/functions/functions/fnc_removeCamouflage.sqf
@@ -32,6 +32,6 @@ private _fnc_onFailure = {
     [_unit, "", 1] call ace_common_fnc_doAnimation;
 };
 
-[CAMOUFLAGE_DURATION, [_unit, _trench], _fnc_onFinish, _fnc_onFailure, localize LSTRING(removeCamouflageProgress)] call ace_common_fnc_progressBar;
+[CAMOUFLAGE_DURATION, [_unit, _trench], _fnc_onFinish, _fnc_onFailure, LLSTRING(removeCamouflageProgress)] call ace_common_fnc_progressBar;
 
 [_unit, "AinvPknlMstpSnonWnonDnon_medic4"] call ace_common_fnc_doAnimation;

--- a/addons/functions/functions/fnc_removeTrench.sqf
+++ b/addons/functions/functions/fnc_removeTrench.sqf
@@ -105,7 +105,7 @@ private _fnc_condition = {
 
     [_trench, _newProgress, 1.5] call FUNC(setTrenchProgress); // not too fast so animation is still visible
 
-    // Show spezial effects
+    // Show special effects
     if (GVAR(allowEffects)) then {
         [QGVAR(digFX), [_trench]] call CBA_fnc_globalEvent;
 

--- a/addons/functions/initSettings.sqf
+++ b/addons/functions/initSettings.sqf
@@ -1,45 +1,46 @@
-//Common Settings
-[QGVAR(allowDigging), "CHECKBOX", [localize LSTRING(settingAllowDigging_displayName), localize LSTRING(settingAllowDigging_tooltip)], localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(allowCamouflage), "CHECKBOX", [localize LSTRING(settingAllowCamouflage_displayName), localize LSTRING(settingAllowCamouflage_tooltip)], localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(camouflageRequireEntrenchmentTool), "CHECKBOX", [localize LSTRING(settingCamouflageRequireEntrenchmentTool_displayName), localize LSTRING(settingCamouflageRequireEntrenchmentTool_tooltip)], localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(stopBuildingAtFatigueMax), "CHECKBOX", [localize LSTRING(stopBuildingAtFatigueMax_displayName), localize LSTRING(stopBuildingAtFatigueMax_tooltip)], localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(buildFatigueFactor), "SLIDER", [localize LSTRING(settingBuildFatigueFactor_displayName), localize LSTRING(settingBuildFatigueFactor_tooltip)], localize LSTRING(settingCategory), [0, 5, 1, 2], true] call CBA_fnc_addSetting;
-[QGVAR(createTrenchMarker), "CHECKBOX", [localize LSTRING(createTrenchMarker_displayName), localize LSTRING(createTrenchMarker_tooltip)], localize LSTRING(settingCategory), false, true, {}, true] call CBA_fnc_addSetting;
-//[QGVAR(allowDiggingInVehicle), "CHECKBOX", [localize LSTRING(allowDiggingInVehicle_displayName), localize LSTRING(allowDiggingInVehicle_tooltip)], localize LSTRING(settingCategory), true, true, {}, true] call CBA_fnc_addSetting;
-[QGVAR(allowEffects), "CHECKBOX", [localize LSTRING(allowEffectse_displayName), localize LSTRING(allowEffects_tooltip)], localize LSTRING(settingCategory), true, true, {}, true] call CBA_fnc_addSetting;
+// Common Settings
+[QGVAR(allowDigging), "CHECKBOX", [LLSTRING(settingAllowDigging_displayName), LLSTRING(settingAllowDigging_tooltip)], LLSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
+[QGVAR(allowCamouflage), "CHECKBOX", [LLSTRING(settingAllowCamouflage_displayName), LLSTRING(settingAllowCamouflage_tooltip)], LLSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
+[QGVAR(camouflageRequireEntrenchmentTool), "CHECKBOX", [LLSTRING(settingCamouflageRequireEntrenchmentTool_displayName), LLSTRING(settingCamouflageRequireEntrenchmentTool_tooltip)], LLSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
+[QGVAR(stopBuildingAtFatigueMax), "CHECKBOX", [LLSTRING(stopBuildingAtFatigueMax_displayName), LLSTRING(stopBuildingAtFatigueMax_tooltip)], LLSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
+[QGVAR(buildFatigueFactor), "SLIDER", [LLSTRING(settingBuildFatigueFactor_displayName), LLSTRING(settingBuildFatigueFactor_tooltip)], LLSTRING(settingCategory), [0, 5, 1, 2], true] call CBA_fnc_addSetting;
+[QGVAR(createTrenchMarker), "CHECKBOX", [LLSTRING(createTrenchMarker_displayName), LLSTRING(createTrenchMarker_tooltip)], LLSTRING(settingCategory), false, true, {}, true] call CBA_fnc_addSetting;
+//[QGVAR(allowDiggingInVehicle), "CHECKBOX", [LLSTRING(allowDiggingInVehicle_displayName), LLSTRING(allowDiggingInVehicle_tooltip)], LLSTRING(settingCategory), true, true, {}, true] call CBA_fnc_addSetting;
+[QGVAR(allowEffects), "CHECKBOX", [LLSTRING(allowEffects_displayName), LLSTRING(allowEffects_tooltip)], LLSTRING(settingCategory), true, true, {}, true] call CBA_fnc_addSetting;
 
-//Trench specific settings
-[QGVAR(allowShortEnvelope), "CHECKBOX", [localize LSTRING(allowShortEnvelope_displayName), localize LSTRING(allowShortEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(shortEnvelopeDigTime), "SLIDER", localize LSTRING(ShortEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 300, 15, 0], true] call CBA_fnc_addSetting;
-[QGVAR(shortEnvelopeRemovalTime), "SLIDER", localize LSTRING(ShortEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 300, -1, 0], true] call CBA_fnc_addSetting;
-[QGVAR(allowSmallEnvelope), "CHECKBOX", [localize LSTRING(allowSmallEnvelope_displayName), localize LSTRING(allowSmallEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(smallEnvelopeDigTime), "SLIDER", localize LSTRING(SmallEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 450, 30, 0], true] call CBA_fnc_addSetting;
-[QGVAR(smallEnvelopeRemovalTime), "SLIDER", localize LSTRING(SmallEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 450, -1, 0], true] call CBA_fnc_addSetting;
-[QGVAR(allowBigEnvelope), "CHECKBOX", [localize LSTRING(allowBigEnvelope_displayName), localize LSTRING(allowBigEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(bigEnvelopeDigTime), "SLIDER", localize LSTRING(BigEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 600, 40, 0], true] call CBA_fnc_addSetting;
-[QGVAR(bigEnvelopeRemovalTime), "SLIDER", localize LSTRING(BigEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 600, -1, 0], true] call CBA_fnc_addSetting;
-[QGVAR(allowGiantEnvelope), "CHECKBOX", [localize LSTRING(allowGiantEnvelope_displayName), localize LSTRING(allowGiantEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(giantEnvelopeDigTime), "SLIDER", localize LSTRING(GiantEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 900, 90, 0], true] call CBA_fnc_addSetting;
-[QGVAR(giantEnvelopeRemovalTime), "SLIDER", localize LSTRING(GiantEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 900, -1, 0], true] call CBA_fnc_addSetting;
-[QGVAR(allowVehicleEnvelope), "CHECKBOX", [localize LSTRING(allowVehicleEnvelope_displayName), localize LSTRING(allowVehicleEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(vehicleEnvelopeDigTime), "SLIDER", localize LSTRING(VehicleEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 1200, 120, 0], true] call CBA_fnc_addSetting;
-[QGVAR(vehicleEnvelopeRemovalTime), "SLIDER", localize LSTRING(VehicleEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 1200, -1, 0], true] call CBA_fnc_addSetting;
-[QGVAR(allowLongEnvelope), "CHECKBOX", [localize LSTRING(allowLongEnvelope_displayName), localize LSTRING(allowLongEnvelope_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(LongEnvelopeDigTime), "SLIDER", localize LSTRING(LongEnvelopeDigTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [5, 1200, 100, 0], true] call CBA_fnc_addSetting;
-[QGVAR(LongEnvelopeRemovalTime), "SLIDER", localize LSTRING(LongEnvelopeRemovalTime), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [-1, 1200, -1, 0], true] call CBA_fnc_addSetting;
+// Trench specific settings
+[QGVAR(allowShortEnvelope), "CHECKBOX", [LLSTRING(allowShortEnvelope_displayName), LLSTRING(allowShortEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(shortEnvelopeDigTime), "SLIDER", LLSTRING(ShortEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 300, 15, 0], true] call CBA_fnc_addSetting;
+[QGVAR(shortEnvelopeRemovalTime), "SLIDER", [LLSTRING(ShortEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 300, -1, 0], true] call CBA_fnc_addSetting;
+[QGVAR(allowSmallEnvelope), "CHECKBOX", [LLSTRING(allowSmallEnvelope_displayName), LLSTRING(allowSmallEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(smallEnvelopeDigTime), "SLIDER", LLSTRING(SmallEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 450, 30, 0], true] call CBA_fnc_addSetting;
+[QGVAR(smallEnvelopeRemovalTime), "SLIDER", [LLSTRING(SmallEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 450, -1, 0], true] call CBA_fnc_addSetting;
+[QGVAR(allowBigEnvelope), "CHECKBOX", [LLSTRING(allowBigEnvelope_displayName), LLSTRING(allowBigEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(bigEnvelopeDigTime), "SLIDER", LLSTRING(BigEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 600, 40, 0], true] call CBA_fnc_addSetting;
+[QGVAR(bigEnvelopeRemovalTime), "SLIDER", [LLSTRING(BigEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 600, -1, 0], true] call CBA_fnc_addSetting;
+[QGVAR(allowGiantEnvelope), "CHECKBOX", [LLSTRING(allowGiantEnvelope_displayName), LLSTRING(allowGiantEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(giantEnvelopeDigTime), "SLIDER", LLSTRING(GiantEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 900, 90, 0], true] call CBA_fnc_addSetting;
+[QGVAR(giantEnvelopeRemovalTime), "SLIDER", [LLSTRING(GiantEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 900, -1, 0], true] call CBA_fnc_addSetting;
+[QGVAR(allowVehicleEnvelope), "CHECKBOX", [LLSTRING(allowVehicleEnvelope_displayName), LLSTRING(allowVehicleEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(vehicleEnvelopeDigTime), "SLIDER", LLSTRING(VehicleEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 1200, 120, 0], true] call CBA_fnc_addSetting;
+[QGVAR(vehicleEnvelopeRemovalTime), "SLIDER", [LLSTRING(VehicleEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 1200, -1, 0], true] call CBA_fnc_addSetting;
+[QGVAR(allowLongEnvelope), "CHECKBOX", [LLSTRING(allowLongEnvelope_displayName), LLSTRING(allowLongEnvelope_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(LongEnvelopeDigTime), "SLIDER", LLSTRING(LongEnvelopeDigTime), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [5, 1200, 100, 0], true] call CBA_fnc_addSetting;
+[QGVAR(LongEnvelopeRemovalTime), "SLIDER", [LLSTRING(LongEnvelopeRemovalTime), LLSTRING(EnvelopeRemovalTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [-1, 1200, -1, 0], true] call CBA_fnc_addSetting;
 
-//Trench hit damage multiplier
-[QGVAR(smallEnvelopeDamageMultiplier), "SLIDER", localize LSTRING(smallEnvelopeDamageMultiplier), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [0.1, 10, 3, 1], true] call CBA_fnc_addSetting;
-[QGVAR(shortEnvelopeDamageMultiplier), "SLIDER", localize LSTRING(shortEnvelopeDamageMultiplier), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [0.1, 10, 2, 1], true] call CBA_fnc_addSetting;
-[QGVAR(bigEnvelopeDamageMultiplier), "SLIDER", localize LSTRING(bigEnvelopeDamageMultiplier), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [0.1, 10, 2, 1], true] call CBA_fnc_addSetting;
-[QGVAR(giantEnvelopeDamageMultiplier), "SLIDER", localize LSTRING(giantEnvelopeDamageMultiplier), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;
-[QGVAR(vehicleEnvelopeDamageMultiplier), "SLIDER", localize LSTRING(vehicleEnvelopeDamageMultiplier), [localize LSTRING(settingCategory), localize LSTRING(trenchSubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;
+// Trench hit damage multiplier
+[QGVAR(smallEnvelopeDamageMultiplier), "SLIDER", LLSTRING(smallEnvelopeDamageMultiplier), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [0.1, 10, 3, 1], true] call CBA_fnc_addSetting;
+[QGVAR(shortEnvelopeDamageMultiplier), "SLIDER", LLSTRING(shortEnvelopeDamageMultiplier), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [0.1, 10, 2, 1], true] call CBA_fnc_addSetting;
+[QGVAR(bigEnvelopeDamageMultiplier), "SLIDER", LLSTRING(bigEnvelopeDamageMultiplier), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [0.1, 10, 2, 1], true] call CBA_fnc_addSetting;
+[QGVAR(giantEnvelopeDamageMultiplier), "SLIDER", LLSTRING(giantEnvelopeDamageMultiplier), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;
+[QGVAR(vehicleEnvelopeDamageMultiplier), "SLIDER", LLSTRING(vehicleEnvelopeDamageMultiplier), [LLSTRING(settingCategory), LLSTRING(trenchSubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;
 
-//Trench decay settings
-[QGVAR(allowTrenchDecay), "CHECKBOX", [localize LSTRING(allowTrenchDecay_displayName), localize LSTRING(allowTrenchDecay_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(decaySubCategory)], false, true] call CBA_fnc_addSetting;
-[QGVAR(timeoutToDecay), "SLIDER", [localize LSTRING(timeoutToDecay_displayName), localize LSTRING(timeoutToDecay_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(decaySubCategory)], [60, 18000, 7200, 0], true] call CBA_fnc_addSetting;
-[QGVAR(decayTime), "SLIDER", [localize LSTRING(decayTime_displayName), localize LSTRING(decayTime_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(decaySubCategory)], [30, 3600, 1800, 0], true] call CBA_fnc_addSetting;
+// Trench decay settings
+[QGVAR(allowTrenchDecay), "CHECKBOX", [LLSTRING(allowTrenchDecay_displayName), LLSTRING(allowTrenchDecay_tooltip)], [LLSTRING(settingCategory), LLSTRING(decaySubCategory)], false, true] call CBA_fnc_addSetting;
+[QGVAR(timeoutToDecay), "SLIDER", [LLSTRING(timeoutToDecay_displayName), LLSTRING(timeoutToDecay_tooltip)], [LLSTRING(settingCategory), LLSTRING(decaySubCategory)], [60, 18000, 7200, 0], true] call CBA_fnc_addSetting;
+[QGVAR(decayTime), "SLIDER", [LLSTRING(decayTime_displayName), LLSTRING(decayTime_tooltip)], [LLSTRING(settingCategory), LLSTRING(decaySubCategory)], [30, 3600, 1800, 0], true] call CBA_fnc_addSetting;
+[QGVAR(playersInAreaRadius), "SLIDER", [LLSTRING(playersInAreaRadius_displayName), LLSTRING(playersInAreaRadius_tooltip)], [LLSTRING(settingCategory), LLSTRING(decaySubCategory)], [0, 1000, 0, 0], true] call CBA_fnc_addSetting;
 
-//Trench hit degradation setting
-[QGVAR(allowHitDecay), "CHECKBOX", [localize LSTRING(allowHitDecay_displayName), localize LSTRING(allowHitDecay_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(hitDecaySubCategory)], true, true] call CBA_fnc_addSetting;
-[QGVAR(hitDecayMultiplier), "SLIDER", [localize LSTRING(hitDecayMultiplier_displayName), localize LSTRING(hitDecayMultiplier_tooltip)], [localize LSTRING(settingCategory), localize LSTRING(hitDecaySubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;
+// Trench hit degradation setting
+[QGVAR(allowHitDecay), "CHECKBOX", [LLSTRING(allowHitDecay_displayName), LLSTRING(allowHitDecay_tooltip)], [LLSTRING(settingCategory), LLSTRING(hitDecaySubCategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(hitDecayMultiplier), "SLIDER", [LLSTRING(hitDecayMultiplier_displayName), LLSTRING(hitDecayMultiplier_tooltip)], [LLSTRING(settingCategory), LLSTRING(hitDecaySubCategory)], [0.1, 10, 1, 1], true] call CBA_fnc_addSetting;

--- a/addons/functions/stringtable.xml
+++ b/addons/functions/stringtable.xml
@@ -316,7 +316,7 @@
         <Key ID="STR_GRAD_Trenches_functions_VehicleEnvelopeRemovalTime">
             <English>Removal time (s) for vehicle envelope trenches.</English>
             <German>Zeit (s) um Fahrzeuggräben zu entfernen.</German>
-            <Russian>Время срытия (сек) окопа для техники./Russian>
+            <Russian>Время срытия (сек) окопа для техники.</Russian>
             <French>Temps de suppression (s) pour les tranchées pour véhicule</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_LongEnvelopeRemovalTime">

--- a/addons/functions/stringtable.xml
+++ b/addons/functions/stringtable.xml
@@ -290,40 +290,46 @@
             <Chinesesimp>挖掘长掩体的时间(秒)</Chinesesimp>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_ShortEnvelopeRemovalTime">
-            <English>Removal time (s) for short envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um kurze Gräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) короткого окопа. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for short envelope trenches.</English>
+            <German>Zeit (s) um kurze Gräben zu entfernen.</German>
+            <Russian>Время срытия (сек) короткого окопа.</Russian>
             <French>Temps de suppression (s) pour les tranchées individuelles</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_SmallEnvelopeRemovalTime">
-            <English>Removal time (s) for small envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um kleine Gräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) малого окопа. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for small envelope trenches.</English>
+            <German>Zeit (s) um kleine Gräben zu entfernen.</German>
+            <Russian>Время срытия (сек) малого окопа.</Russian>
             <French>Temps de suppression (s) pour les petites tranchées</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_BigEnvelopeRemovalTime">
-            <English>Removal time (s) for big envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um große Gräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) среднего окопа. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for big envelope trenches.</English>
+            <German>Zeit (s) um große Gräben zu entfernen.</German>
+            <Russian>Время срытия (сек) среднего окопа.</Russian>
             <French>Temps de suppression (s) pour les petites tranchées (meurtrières)</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_GiantEnvelopeRemovalTime">
-            <English>Removal time (s) for giant envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um riesige Gräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) большого окопа. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for giant envelope trenches.</English>
+            <German>Zeit (s) um riesige Gräben zu entfernen.</German>
+            <Russian>Время срытия (сек) большого окопа.</Russian>
             <French>Temps de suppression (s) pour les grandes tranchées (meurtrières)</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_VehicleEnvelopeRemovalTime">
-            <English>Removal time (s) for vehicle envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um Fahrzeuggräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) окопа для техники. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for vehicle envelope trenches.</English>
+            <German>Zeit (s) um Fahrzeuggräben zu entfernen.</German>
+            <Russian>Время срытия (сек) окопа для техники./Russian>
             <French>Temps de suppression (s) pour les tranchées pour véhicule</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_LongEnvelopeRemovalTime">
-            <English>Removal time (s) for Long envelope trenches. -1 takes the dig time</English>
-            <German>Zeit (s) um Lange Gräben zu entfernen. -1 nimmt die Grabezeit</German>
-            <Russian>Время срытия (сек) длинного окопа. -1 приравнивает к времени откапывания</Russian>
+            <English>Removal time (s) for Long envelope trenches.</English>
+            <German>Zeit (s) um Lange Gräben zu entfernen.</German>
+            <Russian>Время срытия (сек) длинного окопа.</Russian>
             <French>Temps de suppression (s) pour les grandes tranchées</French>
+        </Key>
+        <Key ID="STR_GRAD_Trenches_functions_EnvelopeRemovalTime_tooltip">
+            <English>-1 takes the dig time.</English>
+            <German>-1 nimmt die Grabezeit.</German>
+            <Russian>-1 приравнивает к времени откапывания.</Russian>
+            <French>-1 prend le temps d'excavation.</French>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_HelpDigging">
             <English>Help digging</English>
@@ -539,6 +545,14 @@
             <German>Zeit bis der Graben komplett verschwunden ist</German>
             <Russian>Время, которое занимает полное разрушение окопа</Russian>
         </Key>
+        <Key ID="STR_GRAD_Trenches_functions_playersInAreaRadius_displayName">
+            <English>Player detection radius for disabling decay</English>
+            <German>Spielerdetektionsradius für Grabenverfallsverhinderung</German>
+        </Key>
+        <Key ID="STR_GRAD_Trenches_functions_playersInAreaRadius_tooltip">
+            <English>If players are around a trench in the given radius, the trench will not decay. To turn off player detection set radius to 0.</English>
+            <German>Falls sich Spieler um einen Graben im gegebenen Radius befinden, wird der Graben nicht verfallen. Um Spielerdetektion auszuschalten Radius auf 0 setzen.</German>
+        </Key>
         <Key ID="STR_GRAD_Trenches_functions_trenchSubCategory">
             <English>Trench settings</English>
             <German>Graben Einstellungen</German>
@@ -599,7 +613,7 @@
             <German>Multiplikator Fahrzeuggraben</German>
             <Russian>Множитель урона окопа для техники</Russian>
         </Key>
-        <Key ID="STR_GRAD_Trenches_functions_allowEffectse_displayName">
+        <Key ID="STR_GRAD_Trenches_functions_allowEffects_displayName">
             <English>Enable effects</English>
             <German>Effekte aktivieren</German>
             <Russian>Включить эффекты</Russian>

--- a/addons/functions/stringtable.xml
+++ b/addons/functions/stringtable.xml
@@ -546,12 +546,12 @@
             <Russian>Время, которое занимает полное разрушение окопа</Russian>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_playersInAreaRadius_displayName">
-            <English>Player detection radius for disabling decay</English>
-            <German>Spielerdetektionsradius für Grabenverfallsverhinderung</German>
+            <English>Player detection radius for preventing decay</English>
+            <German>Spielererkennungsradius zur Grabenverfallsverhinderung</German>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_playersInAreaRadius_tooltip">
-            <English>If players are around a trench in the given radius, the trench will not decay. To turn off player detection set radius to 0.</English>
-            <German>Falls sich Spieler um einen Graben im gegebenen Radius befinden, wird der Graben nicht verfallen. Um Spielerdetektion auszuschalten Radius auf 0 setzen.</German>
+            <English>If players are within the given radius around a trench, it will not decay. To turn off player detection set radius to 0.</English>
+            <German>Falls sich Spieler im gegebenen Radius um einen Graben befinden, wird dieser nicht verfallen. Um Spielererkennung auszuschalten Radius auf 0 setzen.</German>
         </Key>
         <Key ID="STR_GRAD_Trenches_functions_trenchSubCategory">
             <English>Trench settings</English>


### PR DESCRIPTION
- Added player detection for trench decay: If a player is detected within the given radius via CBA Settings, it will reset the trench decay timer. Default is 0, which means it's off.
- Added effects when trench decays (visual indicator for nearby players that trench is decaying).
- Removal time CBA Settings use a tooltip to inform the player about setting -1 to use dig time.
- Fixed minor typos in stringtable entry & comment code.
- Replaced all 'localize LSTRING' with the CBA macro LLSTRING.